### PR TITLE
Make this package easier to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Proposed ClassicPress coding standards for reviewing plugins/themes, presented a
 
 ## Installation
 
+These instructions assume the use of Linux, OS X or Windows Subsystem for Linux. PRs that describe how to run the sniffs on Windows are welcome but this is likely to be more difficult.
+
 1. Create a directory dedicated to this project (e.g. `/home/username/cp-plugin-review`)
 2. Change to the directory (`cd /home/username/cp-plugin-review`)
 3. Install WPCS v2.3.0: `composer create-project wp-coding-standards/wpcs wpcs 2.3.0 --no-dev --prefer-dist --keep-vcs` ([more info](https://github.com/WordPress/WordPress-Coding-Standards#installation). Now, WPCS should be installed into the `wpcs` subdirectory.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Proposed ClassicPress coding standards for reviewing plugins/themes, presented a
 
 1. Create a directory dedicated to this project (e.g. `/home/username/cp-plugin-review`)
 2. Change to the directory (`cd /home/username/cp-plugin-review`)
-3. Install WPCS: `composer create-project wp-coding-standards/wpcs --no-dev` ([more info](https://github.com/WordPress/WordPress-Coding-Standards#installation). When prompted with "Do you want to remove the existing VCS history?" type "n" and press Enter. Now, WPCS should be installed into the `wpcs` subdirectory.
+3. Install WPCS v2.3.0: `composer create-project wp-coding-standards/wpcs wpcs 2.3.0 --no-dev --prefer-dist --keep-vcs` ([more info](https://github.com/WordPress/WordPress-Coding-Standards#installation). Now, WPCS should be installed into the `wpcs` subdirectory.
 4. Clone this repository (`git clone https://github.com/TukuToi/CP-Coding-Standards`).
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,41 +1,25 @@
 # CP-Coding-Standards
-An attempt of satisfying everyone and still have some standards.
 
-Public discussion that lead to this ruleset can be found [here](https://forums.classicpress.net/t/adopt-wpcs-for-themes-and-plugin-directory/3755/)
+Proposed ClassicPress coding standards for reviewing plugins/themes, presented as a WPCS phpcs.xml ruleset.
 
-These Coding standards are aimed towards Theme and Plugin _reviewers_.
-Developers are still encouraged to actually use a more thorough Standard ([WPCS `WordPress` standard](https://github.com/WordPress/WordPress-Coding-Standards) would be highly recommended).
-The ruleset should help when revieweing plugins for security issues and not serve as a referece of what quality code looks like.
+## Installation
 
-This rulest is _NOT_ to be used for CP Core either.
+1. Create a directory dedicated to this project (e.g. `/home/username/cp-plugin-review`)
+2. Change to the directory (`cd /home/username/cp-plugin-review`)
+3. Install WPCS: `composer create-project wp-coding-standards/wpcs --no-dev` ([more info](https://github.com/WordPress/WordPress-Coding-Standards#installation). When prompted with "Do you want to remove the existing VCS history?" type "n" and press Enter. Now, WPCS should be installed into the `wpcs` subdirectory.
+4. Clone this repository (`git clone https://github.com/TukuToi/CP-Coding-Standards`).
 
-While crafting code compliant with this ruleset _will_ make it easier for your plugin to be listed on the CP Directory, it does _not_ guarantee it, since there are many other conditions to be fullfilled.
+## Usage
 
-Again, this is NOT a "good" coding standard to improve your CodeBase in general. 
-It would be better to use the more complete WPCS, and if you follow that, it will pass this Ruleset without issues.
+1. Change back to your plugin-review directory (`cd /home/username/cp-plugin-review`)
+2. Clone the plugin you want to analyze (`git clone https://github.com/azurecurve/azrcrv-redirect`).
+3. Change to the plugin's directory (`cd azrcrv-redirect`).
+4. Make note of the plugin's textdomain in the main PHP file (in this case, `azrcrv-r`).
+5. Run the `bin/cpcs` script from this repository as follows: `CPCS_TEXTDOMAIN=azrcrv-r ../CP-Coding-Standards/bin/cpcs .`
 
----
+If you wish to show all warnings/errors even if they have been suppressed by `// phpcs:ignore` comments in the code, then add `--ignore-annotations` to the end of the above command line.
 
-### PRINCIPLES
-- only security related issues should be flagged with the exception:
-    - text domain is passed to localisation functions
-    - text domain passed in function matches declared domain
-- no styling, formatting or documentation issues should be flagged
-- flags should not be silenced
-- should not sniff CSS or JS files. Should sniff _only_ PHP Files.
-- should check for a minimum supported _WP_ Version
-- should not be considered a final judgement - instead a human being should evaluate the results and work on a solution with the developer
-
----
-
-### USAGE
-
-1. Install WPCS as outlined [here](https://github.com/WordPress/WordPress-Coding-Standards#installation)
-2. Download the phpcs.xml file of this repo and put it into the directory you want to analyse
-3. Adjust the Text Domain (and if you want, PHP version and minimum WP Version) inside the XML file (you are looking for `minimum_supported_wp_version` and `text_domain` element values)
-4. `cd` into that directory and run `phpcs --standard=/path/to/phpcs.xml project-folder-or-file`
-
-This will produce an error log like this example 
+This will produce an error log like this example:
 ```
 FILE: path/to/file.php
 ---------------------------------------------------------------------------------------------------------------------------------------------------
@@ -63,15 +47,36 @@ Then make sure you have `PHPCompatibility` installed (if not, [these steps](http
 The error report will now include by default also PHP Compatibility Details.
 To change the minimum and manximum supported PHP version, amend the line `<config name="testVersion" value="5.2-"/>` as you prefer, for example `<config name="testVersion" value="5.5-7.4"/>`
 
----
+## Principles
 
-### CONTRIBUTORS
+- only security related issues should be flagged with the exception:
+    - text domain is passed to localisation functions
+    - text domain passed in function matches declared domain
+- no styling, formatting or documentation issues should be flagged
+- should not sniff CSS or JS files. Should sniff _only_ PHP Files.
+- should check for a minimum supported _WP_ Version
+- should not be considered a final judgement - instead a human being should evaluate the results and work on a solution with the developer
+
+This ruleset represents an attempt of satisfying everyone and still have some standards.
+
+Public discussion that lead to this ruleset can be found [here](https://forums.classicpress.net/t/adopt-wpcs-for-themes-and-plugin-directory/3755/)
+
+These Coding standards are aimed towards Theme and Plugin _reviewers_.
+Developers are still encouraged to actually use a more thorough Standard ([WPCS `WordPress` standard](https://github.com/WordPress/WordPress-Coding-Standards) would be highly recommended).
+The ruleset should help when revieweing plugins for security issues and not serve as a referece of what quality code looks like.
+
+This rulest is _NOT_ to be used for CP Core either.
+
+While crafting code compliant with this ruleset _will_ make it easier for your plugin to be listed on the CP Directory, it does _not_ guarantee it, since there are many other conditions to be fullfilled.
+
+Again, this is NOT a "good" coding standard to improve your CodeBase in general. 
+It would be better to use the more complete WPCS, and if you follow that, it will pass this Ruleset without issues.
+
+## Contributors
 
 To contribute, you will need to know the exact rule you want to add or remove so to add it to the XML file.
 
-The rule throwing an error can be found by passing parameter `-s` to the phpcs command like so 
-`phpcs --standard=/path/to/phpcs.xml -s project-folder-or-file`
-This will then produce a log like this:
+The rule names appear in the log like this:
 ```
 FILE: /Users/bedaschmid/Desktop/vars-master/classes/UpdateClient.class.php
 ---------------------------------------------------------------------------------------------------------------------------------------------------
@@ -81,7 +86,6 @@ FOUND 1 ERROR AFFECTING 1 LINE
 ...
 ---------------------------------------------------------------------------------------------------------------------------------------------------
 ```
-`WordPress.WP.I18n.MissingArgDomain` is the rule throwing the error. 
+`WordPress.WP.I18n.MissingArgDomain` is the rule throwing the error.
 
 Consult the existing rules in the XML file and the related rule documentations to see how to remove, add, configure it more granularly.
-

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ These instructions assume the use of Linux, OS X or Windows Subsystem for Linux.
 
 1. Create a directory dedicated to this project (e.g. `/home/username/cp-plugin-review`)
 2. Change to the directory (`cd /home/username/cp-plugin-review`)
-3. Install WPCS v2.3.0: `composer create-project wp-coding-standards/wpcs wpcs 2.3.0 --no-dev --prefer-dist --keep-vcs` ([more info](https://github.com/WordPress/WordPress-Coding-Standards#installation). Now, WPCS should be installed into the `wpcs` subdirectory.
+3. Install WPCS v2.3.0: `composer create-project wp-coding-standards/wpcs wpcs 2.3.0 --no-dev --prefer-dist --keep-vcs` ([more info](https://github.com/WordPress/WordPress-Coding-Standards#installation)). Now, WPCS should be installed into the `wpcs` subdirectory.
 4. Clone this repository (`git clone https://github.com/TukuToi/CP-Coding-Standards`).
 
 ## Usage

--- a/bin/cpcs
+++ b/bin/cpcs
@@ -4,7 +4,7 @@ set -e # exit on error
 
 if [ -z "$1" ] || [ -z "$CPCS_TEXTDOMAIN" ]; then
 	echo "Usage: CPCS_TEXTDOMAIN=plugin-textdomain $0 plugin-directory-name [other-wpcs-args]"
-	echo "(or use . for current directory)"
+	echo "(to check the current directory, use . for plugin-directory-name)"
 	exit 1
 fi
 

--- a/bin/cpcs
+++ b/bin/cpcs
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e # exit on error
+
+if [ -z "$1" ] || [ -z "$CPCS_TEXTDOMAIN" ]; then
+	echo "Usage: CPCS_TEXTDOMAIN=plugin-textdomain $0 plugin-directory-name [other-wpcs-args]"
+	echo "(or use . for current directory)"
+	exit 1
+fi
+
+# wpcs needs an absolute path for installed_paths.
+WPCS_DIR="$(cd "$(dirname "$0")"; cd ../..; echo "$(pwd)/wpcs")"
+
+if [ ! -d "$WPCS_DIR" ] || [ ! -x "$WPCS_DIR/vendor/bin/phpcs" ]; then
+	echo "Please install WPCS into $WPCS_DIR :"
+	echo "https://github.com/WordPress/WordPress-Coding-Standards#installation"
+	exit 1
+fi
+
+"$WPCS_DIR/vendor/bin/phpcs" \
+	--runtime-set text_domain "$CPCS_TEXTDOMAIN" \
+	--runtime-set installed_paths "$WPCS_DIR" \
+	--standard="$(dirname "$0")/../phpcs.xml" \
+	-s -v "$@"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,7 @@
 	</description>
 
 	<!-- start config -->
-	
+
 	<!-- style the error output a little so it is easier to spot warning/errors-->
 	<arg name="colors"/>
 
@@ -32,7 +32,7 @@
 	<!-- PHP Version Test. Uncomment to use. Install with https://github.com/PHPCompatibility/PHPCompatibility#installation-via-a-git-check-out-to-an-arbitrary-directory-method-2. -->
 	<!-- <config name="testVersion" value="5.2-"/>
 	<rule ref="PHPCompatibility">
-	    <include-pattern>*\.php$</include-pattern>
+		<include-pattern>*\.php$</include-pattern>
 	</rule> -->
 
 	<!-- end config -->
@@ -52,10 +52,10 @@
 		<!-- These rules are already excluded with above bulk rule-exclusions
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase"/>
-	  	<exclude name="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase"/>
-	  	<exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
-	  	<exclude name="WordPress.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed"/>
-	  	<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase"/>
+		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
+		<exclude name="WordPress.WhiteSpace.DisallowInlineTabs.NonIndentTabsUsed"/>
+		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter"/>
 		<exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore"/>
 		<exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found"/>
 		-->
@@ -66,8 +66,8 @@
 		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceBeforeArrayCloser"/>
 		<exclude name="WordPress.Arrays.ArrayKeySpacingRestrictions.NoSpacesAroundArrayKeys"/>
 		<exclude name="WordPress.Arrays.CommaAfterArrayItem.NoSpaceAfterComma"/>
-	  	<exclude name="WordPress.Arrays.CommaAfterArrayItem.SpaceAfterComma"/>
-	  	<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned"/>
+		<exclude name="WordPress.Arrays.CommaAfterArrayItem.SpaceAfterComma"/>
+		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned"/>
 		<exclude name="WordPress.Classes.ClassInstantiation.MissingParenthesis"/>
 		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
 		<exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery"/>
@@ -77,72 +77,72 @@
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotValidated"/>
 		<exclude name="WordPress.WP.EnqueuedResourceParameters.MissingVersion"/>
-	  	<exclude name="WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion"/>
+		<exclude name="WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion"/>
 
-	  	<!-- Remove Squiz rules in Bulk -->
-	  	<exclude name="Squiz.Commenting"/>
-	  	<exclude name="Squiz.NamingConventions"/>
-	  	<exclude name="Squiz.WhiteSpace"/>
+		<!-- Remove Squiz rules in Bulk -->
+		<exclude name="Squiz.Commenting"/>
+		<exclude name="Squiz.NamingConventions"/>
+		<exclude name="Squiz.WhiteSpace"/>
 
-	  	<!-- These rules are already excluded with above more generic rule-exclusions
-	  	<exclude name="Squiz.Commenting.BlockComment.HasEmptyLine"/>
-	  	<exclude name="Squiz.Commenting.BlockComment.HasEmptyLineBefore"/>
-	  	<exclude name="Squiz.Commenting.ClassComment.Missing"/>
-	  	<exclude name="Squiz.Commenting.ClassComment.SpacingAfter"/>
-	  	<exclude name="Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar"/>
-	  	<exclude name="Squiz.Commenting.FileComment.Missing"/>
-	  	<exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
-	  	<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment"/>
-	  	<exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen"/>
-	  	<exclude name="Squiz.Commenting.FileComment.WrongStyle"/>
-	  	<exclude name="Squiz.Commenting.FunctionComment.Missing"/>
-	  	<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
-	  	<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
-	  	<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
-	  	<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
-	  	<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
-	  	<exclude name="Squiz.Commenting.InlineComment.SpacingBefore"/>
-	  	<exclude name="Squiz.Commenting.LongConditionClosingComment.Missing"/>
-	  	<exclude name="Squiz.Commenting.VariableComment.Missing"/> 
-	  	<exclude name="Squiz.Commenting.VariableComment.MissingVar"/>
-	  	<exclude name="Squiz.Commenting.VariableComment.WrongStyle"/>
-	  	<exclude name="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>
-	  	<exclude name="Squiz.WhiteSpace.FunctionClosingBraceSpace.SpacingBeforeClose"/>
-	  	<exclude name="Squiz.WhiteSpace.FunctionSpacing.AfterLast"/>
-	  	<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine"/>
-	  	-->
+		<!-- These rules are already excluded with above more generic rule-exclusions
+		<exclude name="Squiz.Commenting.BlockComment.HasEmptyLine"/>
+		<exclude name="Squiz.Commenting.BlockComment.HasEmptyLineBefore"/>
+		<exclude name="Squiz.Commenting.ClassComment.Missing"/>
+		<exclude name="Squiz.Commenting.ClassComment.SpacingAfter"/>
+		<exclude name="Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar"/>
+		<exclude name="Squiz.Commenting.FileComment.Missing"/>
+		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
+		<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment"/>
+		<exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen"/>
+		<exclude name="Squiz.Commenting.FileComment.WrongStyle"/>
+		<exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag"/>
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop"/>
+		<exclude name="Squiz.Commenting.FunctionComment.SpacingAfterParamType"/>
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
+		<exclude name="Squiz.Commenting.InlineComment.SpacingBefore"/>
+		<exclude name="Squiz.Commenting.LongConditionClosingComment.Missing"/>
+		<exclude name="Squiz.Commenting.VariableComment.Missing"/>
+		<exclude name="Squiz.Commenting.VariableComment.MissingVar"/>
+		<exclude name="Squiz.Commenting.VariableComment.WrongStyle"/>
+		<exclude name="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>
+		<exclude name="Squiz.WhiteSpace.FunctionClosingBraceSpace.SpacingBeforeClose"/>
+		<exclude name="Squiz.WhiteSpace.FunctionSpacing.AfterLast"/>
+		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine"/>
+		-->
 
-	  	<!-- Remove Squiz Specific rules -->
-	  	<exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceBeforeBracket"/>
-	  	<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
-	  	<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword"/>
-	  	<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceAfterEquals"/>
-	  	<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeEquals"/>
-	  	<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen"/>
-	  	<exclude name="Squiz.Operators.IncrementDecrementUsage.Found"/>
-	  	<exclude name="Squiz.Operators.ValidLogicalOperators.NotAllowed"/>
-	  	<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
-	  	<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found"/>
-	  	<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure"/>
+		<!-- Remove Squiz Specific rules -->
+		<exclude name="Squiz.Arrays.ArrayBracketSpacing.SpaceBeforeBracket"/>
+		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
+		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword"/>
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceAfterEquals"/>
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeEquals"/>
+		<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen"/>
+		<exclude name="Squiz.Operators.IncrementDecrementUsage.Found"/>
+		<exclude name="Squiz.Operators.ValidLogicalOperators.NotAllowed"/>
+		<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
+		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found"/>
+		<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure"/>
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd"/>
-	  	<exclude name="Squiz.Strings.ConcatenationSpacing.PaddingFound"/>
+		<exclude name="Squiz.Strings.ConcatenationSpacing.PaddingFound"/>
 
-	  	<!-- Remove PEAR rules in Bulk -->
-	  	<exclude name="PEAR.Commenting"/>
-	  	<exclude name="PEAR.Functions.FunctionCallSignature"/>
+		<!-- Remove PEAR rules in Bulk -->
+		<exclude name="PEAR.Commenting"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature"/>
 
-	  	<!-- These rules are already excluded with above more generic rule-exclusions
-	  	<exclude name="PEAR.Commenting.FileComment.WrongStyle"/>
-	  	<exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket"/>
-		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket"/>
+		<!-- These rules are already excluded with above more generic rule-exclusions
+		<exclude name="PEAR.Commenting.FileComment.WrongStyle"/>
 		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket"/>
 		-->
 
 		<!-- Remove PEAR Specific rules -->
 		<exclude name="PEAR.Files.IncludingFile.BracketsNotRequired"/>
-		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent"/> 
+		<exclude name="PSR2.ControlStructures.SwitchDeclaration.BreakIndent"/>
 		<exclude name="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonCASE"/>
 
 		<!-- Remove PSR2 Specific rules -->
@@ -154,22 +154,22 @@
 		<exclude name="Generic.Formatting"/>
 		<exclude name="Generic.WhiteSpace"/>
 
-	  	<!-- These rules are already excluded with above more generic rule-exclusions
-	  	<exclude name="Generic.Commenting.DocComment.SpacingBetween"/>
-	  	<exclude name="Generic.Files.EndFileNewline.NotFound"/>
+		<!-- These rules are already excluded with above more generic rule-exclusions
+		<exclude name="Generic.Commenting.DocComment.SpacingBetween"/>
+		<exclude name="Generic.Files.EndFileNewline.NotFound"/>
 		<exclude name="Generic.Files.EndFileNoNewline.Found"/>
-		<exclude name="Generic.Files.LineEndings.InvalidEOLChar"/> 
+		<exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
 		<exclude name="Generic.Formatting.MultipleStatementAlignment.IncorrectWarning"/>
 		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning"/>
 		<exclude name="Generic.Formatting.SpaceAfterCast.NoSpace"/>
-	  	<exclude name="Generic.WhiteSpace.ArbitraryParenthesesSpacing.SpaceAfterOpen"/>
+		<exclude name="Generic.WhiteSpace.ArbitraryParenthesesSpacing.SpaceAfterOpen"/>
 		<exclude name="Generic.WhiteSpace.ArbitraryParenthesesSpacing.SpaceBeforeClose"/>
 		<exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed"/>
 		<exclude name="Generic.WhiteSpace.DisallowTabIndent.TabsUsed"/>
 		-->
 
 		<!-- Remove Generic Specific rules -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/> 
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
 		<exclude name="Generic.Classes.OpeningBraceSameLine.SpaceBeforeBrace"/>
 		<exclude name="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma"/>
 		<exclude name="Generic.PHP.ClosingPHPTag.NotFound"/>
@@ -183,7 +183,7 @@
 			<property name="space_before_colon" value="optional"/>
 		</properties>
 	</rule>
-	
+
 	<!-- Do not check for translator comments when placeholder is included -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,9 +10,6 @@
 	<!-- style the error output a little so it is easier to spot warning/errors-->
 	<arg name="colors"/>
 
-	<!-- ignore any phpcs: annotations -->
-	<arg name="ignore-annotations" />
-
 	<!-- only sniff PHP-->
 	<arg name="extensions" value="php" />
 
@@ -20,10 +17,14 @@
 	<config name="minimum_supported_wp_version" value="1.0.0"/>
 
 	<!-- The Custom Text Domain of this Plugin or Theme -->
+	<![CDATA[
+		Override this with `--runtime-set text_domain plugin-domain` on command line.
+		See: https://github.com/WordPress/WordPress-Coding-Standards/blob/2.3.0/WordPress/Sniffs/WP/I18nSniff.php#L195-L196
+	]]>
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="MY_DOMAIN"/><!-- change only this value. Add line if more than one text domain. Not suggested.-->
+				<element value="MY_DOMAIN"/>
 			</property>
 		</properties>
 	</rule>
@@ -124,6 +125,7 @@
 	  	<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure"/>
 	  	<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
 	  	<exclude name="Squiz.Strings.ConcatenationSpacing.PaddingFound"/>
+		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd"/>
 
 	  	<!-- Remove PEAR rules in Bulk -->
 	  	<exclude name="PEAR.Commenting"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -72,9 +72,9 @@
 		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
 		<exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery"/>
 		<exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching"/>
-		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 		<exclude name="WordPress.PHP.StrictComparisons.LooseComparison"/>
 		<exclude name="WordPress.PHP.StrictInArray.MissingTrueStrict"/>
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 		<exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotValidated"/>
 		<exclude name="WordPress.WP.EnqueuedResourceParameters.MissingVersion"/>
 	  	<exclude name="WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion"/>
@@ -92,8 +92,8 @@
 	  	<exclude name="Squiz.Commenting.DocCommentAlignment.SpaceBeforeStar"/>
 	  	<exclude name="Squiz.Commenting.FileComment.Missing"/>
 	  	<exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
-	  	<exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen"/>
 	  	<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment"/>
+	  	<exclude name="Squiz.Commenting.FileComment.SpacingAfterOpen"/>
 	  	<exclude name="Squiz.Commenting.FileComment.WrongStyle"/>
 	  	<exclude name="Squiz.Commenting.FunctionComment.Missing"/>
 	  	<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
@@ -121,11 +121,11 @@
 	  	<exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen"/>
 	  	<exclude name="Squiz.Operators.IncrementDecrementUsage.Found"/>
 	  	<exclude name="Squiz.Operators.ValidLogicalOperators.NotAllowed"/>
+	  	<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
 	  	<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found"/>
 	  	<exclude name="Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure"/>
-	  	<exclude name="Squiz.PHP.CommentedOutCode.Found"/>
-	  	<exclude name="Squiz.Strings.ConcatenationSpacing.PaddingFound"/>
 		<exclude name="Squiz.PHP.EmbeddedPhp.ContentBeforeEnd"/>
+	  	<exclude name="Squiz.Strings.ConcatenationSpacing.PaddingFound"/>
 
 	  	<!-- Remove PEAR rules in Bulk -->
 	  	<exclude name="PEAR.Commenting"/>


### PR DESCRIPTION
This PR updates the readme to add full installation and usage instructions at the top of the readme. It adds a `bin/cpcs` script which is both an easier way to run this ruleset and a next step towards automating this process for plugins. This PR also makes a couple of changes to the `phpcs.xml` rules:

- Disable the `Squiz.PHP.EmbeddedPhp.ContentBeforeEnd` formatting rule which showed up for me while I was playing with this project.
- Respect `phpcs:ignore` annotations, and document in the readme how to show all warnings/errors including those that are ignored. Specific `phpcs:ignore` comments accompanied by explanations of why a given rule is being ignored should be accepted as a way to pass the coding standards checks.

It's better to specify options _at runtime_ rather than requiring users to edit the `phpcs.xml` directly. For the `text_domain` setting, this can be done via `--runtime-set text_domain plugin-textdomain`: https://github.com/WordPress/WordPress-Coding-Standards/blob/7da1894633f168fe244afc6de00d141f27517b62/WordPress/Sniffs/WP/I18nSniff.php#L193-L197

The `minimum_supported_wp_version` setting should have similar treatment, but I think this should be saved for a separate PR: https://github.com/WordPress/WordPress-Coding-Standards/blob/dc2f21771cb2b5336a7e6bb6616abcdfa691d7de/WordPress/Helpers/MinimumWPVersionTrait.php#L60